### PR TITLE
make it work with the new npm website

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,17 +15,17 @@ module.exports = username => {
 		const email = values[1];
 		const $ = cheerio.load(res.body);
 
-		let avatar = $('.avatar img').attr('src');
+		let avatar = $('img[src^="https://s.gravatar.com"]').attr('src');
 		avatar = avatar ? avatar.replace(/^(https:\/\/)s\./, '$1').replace(/&default=retro$/, '') : null;
 
+		const $sidebar = $('[class^="profile__sidebar"]');
+
 		return {
-			name: $('.fullname').text() || null,
+			name: $sidebar.find('.black-50.mv2').text() || null,
 			avatar,
 			email: email || null,
-			homepage: $('.homepage a').attr('href') || null,
-			github: $('.github a').text().slice(1) || null,
-			twitter: $('.twitter a').text().slice(1) || null,
-			freenode: $('.freenode a').text() || null
+			github: $sidebar.find('a[href^="https://github.com/"]').text().slice(1) || null,
+			twitter: $sidebar.find('a[href^="https://twitter.com/"]').text().slice(1) || null
 		};
 	}).catch(err => {
 		if (err.statusCode === 404) {

--- a/readme.md
+++ b/readme.md
@@ -26,10 +26,8 @@ npmUser('sindresorhus').then(user => {
 		name: 'Sindre Sorhus',
 		avatar: 'https://gravatar.com/avatar/d36a92237c75c5337c17b60d90686bf9?size=496',
 		email: 'sindresorhus@gmail.com',
-		homepage: 'https://sindresorhus.com',
 		github: 'sindresorhus',
-		twitter: 'sindresorhus',
-		freenode: null
+		twitter: 'sindresorhus'
 	}
 	*/
 });

--- a/test.js
+++ b/test.js
@@ -3,14 +3,11 @@ import m from '.';
 
 test('user: sindresorhus', async t => {
 	const user = await m('sindresorhus');
-	console.log(user);
 	t.is(user.name, 'Sindre Sorhus');
 	t.regex(user.avatar, /gravatar\.com\/avatar/);
 	t.is(user.email, 'sindresorhus@gmail.com');
-	t.is(user.homepage, 'https://sindresorhus.com');
 	t.is(user.github, 'sindresorhus');
 	t.is(user.twitter, 'sindresorhus');
-	t.is(user.freenode, null);
 });
 
 test('user: npm', async t => {
@@ -18,8 +15,15 @@ test('user: npm', async t => {
 	t.is(user.name, 'No Problem, Meatbag');
 	t.regex(user.avatar, /gravatar\.com\/avatar/);
 	t.is(user.email, 'npm@npmjs.com');
-	t.is(user.homepage, 'https://npmjs.org');
 	t.is(user.github, 'npm');
 	t.is(user.twitter, 'npmjs');
-	t.is(user.freenode, null);
+});
+
+test('user: tj', async t => {
+	const user = await m('tj');
+	t.is(user.name, null);
+	t.regex(user.avatar, /gravatar\.com\/avatar/);
+	t.is(user.email, 'tj@vision-media.ca');
+	t.is(user.github, null);
+	t.is(user.twitter, null);
 });


### PR DESCRIPTION
npm has a new website: https://twitter.com/seldo/status/976568040887222272

This PR updates the cheerio selectors to find user profile data on the newly structured profile pages. Unfortunately they're not using descriptive class names for this stuff any more, so the selectors are a little more ugly now, but they work.

`homepage` is no longer included, as npm no longer displays it. This is an anti-spam measure on their part. `freenode` is also omitted now because they're [no longer displaying that](https://gist.github.com/zeke/5ccba079a18aef48af421f72ed10a3ef) either.

Resolves #9 