### PR TITLE
Fix 404 error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ export default async function npmUser(username) {
 			twitter: $sidebar.find('a[href^="https://twitter.com/"]').text().slice(1) || undefined,
 		};
 	} catch (error) {
-		if (error.statusCode === 404) {
+		if (error.response.status === 404) {
 			error.message = 'User doesn\'t exist';
 		}
 

--- a/test.js
+++ b/test.js
@@ -39,3 +39,10 @@ test('user: tj', async t => {
 
 	t.regex(user.avatar, avatarRegex);
 });
+
+test('handles non-existent user', async t => {
+	await t.throwsAsync(
+		npmUser('sindresorhus123'),
+		{message: 'User doesn\'t exist'},
+	);
+});


### PR DESCRIPTION
With the switch to `ky`, the HTTP status code is now on `error.response.status`.